### PR TITLE
Adding maven dependency details to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ cd nlapi-java
 ./gradlew distZip    
 ```
 
+## Add maven dependency
+
+```
+<dependency>
+    <groupId>ai.expert</groupId>
+    <artifactId>nlapi-java-sdk</artifactId>
+    <version>2.1.2</version>
+</dependency>
+
+```
+
 
 ## Setting your credentials
 


### PR DESCRIPTION
Without the maven details, the SDK can't be used in a java project.