### PR TITLE
Language for each request

### DIFF
--- a/src/main/java/ai/expert/nlapi/v2/API.java
+++ b/src/main/java/ai/expert/nlapi/v2/API.java
@@ -87,6 +87,7 @@ public class API {
 
     public enum Languages {
 
+        notKnown("unknown", "Unknown"),
         de("de", "German"),
         en("en", "English"),
         es("es", "Spanish"),

--- a/src/main/java/ai/expert/nlapi/v2/cloud/Analyzer.java
+++ b/src/main/java/ai/expert/nlapi/v2/cloud/Analyzer.java
@@ -33,8 +33,7 @@ import org.apache.logging.log4j.Logger;
 public class Analyzer {
 
     private static final Logger logger = LogManager.getLogger();
-
-    private boolean isLanguageSet = false;
+    
     private final Authentication authentication;
     private final AnalyzerConfig configuration;
     private String URL;

--- a/src/main/java/ai/expert/nlapi/v2/cloud/AnalyzerConfig.java
+++ b/src/main/java/ai/expert/nlapi/v2/cloud/AnalyzerConfig.java
@@ -26,7 +26,7 @@ import lombok.Value;
 public class AnalyzerConfig {
 
     API.Versions version;
-    String context;
+    API.Contexts context;
     API.Languages language;
     Authentication authentication;
 }

--- a/src/test/java/ai/expert/nlapi/v2/test/DisambiguationTest.java
+++ b/src/test/java/ai/expert/nlapi/v2/test/DisambiguationTest.java
@@ -37,7 +37,7 @@ public class DisambiguationTest {
     public static Analyzer createAnalyzer(Authentication authentication) throws Exception {
         return new Analyzer(AnalyzerConfig.builder()
                                           .withVersion(API.Versions.V2)
-                                          .withContext("standard")
+                                          .withContext(API.Contexts.STANDARD)
                                           .withLanguage(API.Languages.en)
                                           .withAuthentication(authentication)
                                           .build());

--- a/src/test/java/ai/expert/nlapi/v2/test/EntitiesTest.java
+++ b/src/test/java/ai/expert/nlapi/v2/test/EntitiesTest.java
@@ -37,7 +37,7 @@ public class EntitiesTest {
     public static Analyzer createAnalyzer(Authentication authentication) throws Exception {
         return new Analyzer(AnalyzerConfig.builder()
                                           .withVersion(API.Versions.V2)
-                                          .withContext("standard")
+                                          .withContext(API.Contexts.STANDARD)
                                           .withLanguage(API.Languages.en)
                                           .withAuthentication(authentication)
                                           .build());

--- a/src/test/java/ai/expert/nlapi/v2/test/FullAnalysisParsingTest.java
+++ b/src/test/java/ai/expert/nlapi/v2/test/FullAnalysisParsingTest.java
@@ -35,7 +35,7 @@ public class FullAnalysisParsingTest {
     public static Analyzer createAnalyzer(Authentication authentication) throws Exception {
         return new Analyzer(AnalyzerConfig.builder()
                                           .withVersion(API.Versions.V2)
-                                          .withContext("standard")
+                                          .withContext(API.Contexts.STANDARD)
                                           .withLanguage(API.Languages.en)
                                           .withAuthentication(authentication)
                                           .build());

--- a/src/test/java/ai/expert/nlapi/v2/test/FullAnalysisTest.java
+++ b/src/test/java/ai/expert/nlapi/v2/test/FullAnalysisTest.java
@@ -37,7 +37,7 @@ public class FullAnalysisTest {
     public static Analyzer createAnalyzer(Authentication authentication) throws Exception {
         return new Analyzer(AnalyzerConfig.builder()
                                           .withVersion(API.Versions.V2)
-                                          .withContext("standard")
+                                          .withContext(API.Contexts.STANDARD)
                                           .withLanguage(API.Languages.en)
                                           .withAuthentication(authentication)
                                           .build());

--- a/src/test/java/ai/expert/nlapi/v2/test/RelationsTest.java
+++ b/src/test/java/ai/expert/nlapi/v2/test/RelationsTest.java
@@ -37,7 +37,7 @@ public class RelationsTest {
     public static Analyzer createAnalyzer(Authentication authentication) throws Exception {
         return new Analyzer(AnalyzerConfig.builder()
                                           .withVersion(API.Versions.V2)
-                                          .withContext("standard")
+                                          .withContext(API.Contexts.STANDARD)
                                           .withLanguage(API.Languages.en)
                                           .withAuthentication(authentication)
                                           .build());

--- a/src/test/java/ai/expert/nlapi/v2/test/RelevantsTest.java
+++ b/src/test/java/ai/expert/nlapi/v2/test/RelevantsTest.java
@@ -37,7 +37,7 @@ public class RelevantsTest {
     public static Analyzer createAnalyzer(Authentication authentication) throws Exception {
         return new Analyzer(AnalyzerConfig.builder()
                                           .withVersion(API.Versions.V2)
-                                          .withContext("standard")
+                                          .withContext(API.Contexts.STANDARD)
                                           .withLanguage(API.Languages.en)
                                           .withAuthentication(authentication)
                                           .build());

--- a/src/test/java/ai/expert/nlapi/v2/test/SentimentTest.java
+++ b/src/test/java/ai/expert/nlapi/v2/test/SentimentTest.java
@@ -37,7 +37,7 @@ public class SentimentTest {
     public static Analyzer createAnalyzer(Authentication authentication) throws Exception {
         return new Analyzer(AnalyzerConfig.builder()
                                           .withVersion(API.Versions.V2)
-                                          .withContext("standard")
+                                          .withContext(API.Contexts.STANDARD)
                                           .withLanguage(API.Languages.en)
                                           .withAuthentication(authentication)
                                           .build());


### PR DESCRIPTION
Working on Elasticsearch plugin I ran into Use Case where Users will ingest documents on different languages that we need to process using nlapi.
Idea behind this pull request is to enable users of SDK, to initialize Analyzer object without language, or to treat that language as "default" and then let them pass the language again as parameter on each method call.

This is draft version as there might be some business logic that must be supported but any comment in what direction to go is welcomed.